### PR TITLE
feat: add source-backed health assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![React 18](https://img.shields.io/badge/react-18-blue.svg)](https://reactjs.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.104+-green.svg)](https://fastapi.tiangolo.com/)
 
-A privacy-first, local AI-driven sexual health education system powered by Google's Gemma 3 1B model. Provides culturally sensitive, age-appropriate sexual health education in multiple languages.
+A privacy-first, local AI-driven sexual health education system powered by a configurable health-tuned model based on Google Gemma 4. Answers are limited to English and Simplified Chinese and are backed by reviewable literature.
 
 ## 🚀 Quick Start
 
@@ -60,7 +60,8 @@ A privacy-first, local AI-driven sexual health education system powered by Googl
 ## ✨ Features
 
 - 🔒 **Privacy-First**: Local AI processing, no data leaves your system
-- 🌍 **Multi-Language**: English and Chinese support
+- 🌍 **Supported Languages**: English and Simplified Chinese
+- 📚 **Source-Backed Answers**: Inline citations and a literature review workflow
 - 🎤 **Voice Input**: Speech recognition with Whisper
 - 📄 **Document Analysis**: PDF processing and knowledge extraction
 - 🎨 **Modern UI**: Bauhaus-inspired design system
@@ -152,7 +153,7 @@ After running tests with coverage:
 - **Pytest** for testing
 
 ### AI & ML
-- **Google Gemma 3 1B** (primary model)
+- **Google Gemma 4 health-tuned model** (configurable local artifact)
 - **OpenAI Whisper** for speech recognition
 - **Transformers** library
 - **PyTorch** for model inference
@@ -213,7 +214,7 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 
 ## 🙏 Acknowledgments
 
-- Google for the Gemma 3 1B model
+- Google for the Gemma model family
 - OpenAI for Whisper speech recognition
 - The open-source community for the amazing tools and libraries
 

--- a/backend/app/api/ai.py
+++ b/backend/app/api/ai.py
@@ -179,14 +179,14 @@ async def get_model_status():
         # Return mock status for now
         return ModelStatusResponse(
             status="ready",
-            modelName="Gemma 3 1B",
+            modelName="Gemma 4 Health Tuned",
             lastUpdated=None
         )
     except Exception as e:
         logger.error(f"Model status check error: {str(e)}")
         return ModelStatusResponse(
             status="error",
-            modelName="Gemma 3 1B",
+            modelName="Gemma 4 Health Tuned",
             lastUpdated=None
         )
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -9,7 +9,7 @@ from app.core.dependencies import get_ai_service, get_audio_service, get_documen
 
 def get_current_active_user() -> User:
     """Get current active user (stub for testing)."""
-    return User(id=1, email="test@example.com", is_active=True)
+    return User(id=1, email="test@example.com", is_active=True, role="admin")
 
 
 def get_db():

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,6 +1,14 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import ai, auth, chat, users, audio_streaming, knowledge
+from app.api.v1.endpoints import (
+    ai,
+    auth,
+    chat,
+    users,
+    audio_streaming,
+    knowledge,
+    literature,
+)
 
 api_router = APIRouter()
 
@@ -10,3 +18,4 @@ api_router.include_router(chat.router, tags=["chat"])
 api_router.include_router(ai.router, prefix="/ai", tags=["ai"])
 api_router.include_router(audio_streaming.router, prefix="/audio-streaming", tags=["audio-streaming"])
 api_router.include_router(knowledge.router, prefix="/knowledge", tags=["knowledge"])
+api_router.include_router(literature.router, prefix="/literature", tags=["literature"])

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -2,7 +2,8 @@
 Chat endpoints for AI conversations.
 """
 
-from typing import Any, Dict, Optional
+import re
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -10,6 +11,7 @@ from pydantic import BaseModel, Field
 from app.api.deps import get_ai_service
 from app.core.logging import get_logger
 from app.services.ai_service import AIService
+from app.services.literature_service import LiteratureSource, literature_service
 
 logger = get_logger(__name__)
 router = APIRouter()
@@ -32,7 +34,105 @@ class ChatResponse(BaseModel):
     language_detected: str
     confidence: float
     safety_score: float
+    status: Literal["answered", "refused"] = "answered"
+    citations: List[Dict[str, Any]] = Field(default_factory=list)
+    refusal_reason: Optional[str] = None
     processing_time: Optional[float] = None
+
+
+SUPPORTED_CHAT_LANGUAGES = {"en", "zh-CN"}
+
+
+def _normalize_language(language: Optional[str]) -> Optional[str]:
+    """Normalize UI locale codes to supported chat language codes."""
+    if not language:
+        return None
+    if language.lower().startswith("en"):
+        return "en"
+    if language in {"zh", "zh-CN"} or language.lower().startswith("zh-cn"):
+        return "zh-CN"
+    return language
+
+
+def _detect_supported_language(text: str, requested_language: Optional[str]) -> str:
+    """Detect supported chat languages and preserve explicit supported choices."""
+    requested_language = _normalize_language(requested_language)
+    if requested_language in SUPPORTED_CHAT_LANGUAGES:
+        return requested_language
+    if re.search(r"[\u4e00-\u9fff]", text):
+        return "zh-CN"
+    return "en"
+
+
+def _is_unsupported_language(text: str, requested_language: Optional[str]) -> bool:
+    """Return true when the request is clearly outside supported languages."""
+    requested_language = _normalize_language(requested_language)
+    if requested_language and requested_language not in SUPPORTED_CHAT_LANGUAGES:
+        return True
+    if re.search(r"[\u4e00-\u9fff]", text):
+        return False
+    # Basic non-English signal for common accented Latin punctuation/letters.
+    return bool(re.search(r"[¿¡áéíóúñüÁÉÍÓÚÑÜ]", text))
+
+
+def _unsupported_language_response(
+    requested_language: Optional[str],
+) -> ChatResponse:
+    """Build the supported-language refusal response."""
+    language = "zh-CN" if requested_language == "zh-CN" else "en"
+    if language == "zh-CN":
+        response = "目前仅支持简体中文和英语。请使用其中一种语言重新提问。"
+    else:
+        response = (
+            "Only English and Simplified Chinese are supported. "
+            "Please ask your question again in one of those languages."
+        )
+    return ChatResponse(
+        response=response,
+        language=language,
+        language_detected=requested_language or "unsupported",
+        confidence=0.0,
+        safety_score=1.0,
+        status="refused",
+        citations=[],
+        refusal_reason="unsupported_language",
+    )
+
+
+def _no_source_response(language: str, detected_language: str) -> ChatResponse:
+    """Build a refusal response for missing approved literature."""
+    if language == "zh-CN":
+        response = "我没有找到可审核的已批准资料来支持这个问题，因此不能可靠回答。"
+    else:
+        response = (
+            "I could not find approved, reviewable literature to support this "
+            "answer, so I cannot answer it reliably."
+        )
+    return ChatResponse(
+        response=response,
+        language=language,
+        language_detected=detected_language,
+        confidence=0.0,
+        safety_score=1.0,
+        status="refused",
+        citations=[],
+        refusal_reason="no_approved_source",
+    )
+
+
+def _citation_dict(source: LiteratureSource) -> Dict[str, Any]:
+    """Return compact citation metadata for chat responses."""
+    return {
+        "id": source.id,
+        "title": source.title,
+        "publisher": source.publisher,
+        "language": source.language,
+        "source_type": source.source_type,
+        "url": source.url,
+        "excerpt": source.excerpt,
+        "doi": source.doi,
+        "pmid": source.pmid,
+    }
 
 
 @router.post("/chat", response_model=ChatResponse)
@@ -52,12 +152,35 @@ async def chat_with_ai(
     try:
         logger.info(f"Processing chat message: {message.message[:50]}...")
 
+        if _is_unsupported_language(message.message, message.language):
+            return _unsupported_language_response(message.language)
+
+        response_language = _detect_supported_language(
+            message.message, message.language
+        )
+        detected_language = response_language
+        citations = literature_service.retrieve(
+            message.message, response_language
+        )
+
+        if not citations:
+            return _no_source_response(response_language, detected_language)
+
         # Generate AI response
         response = await ai_service.generate_response(
             message=message.message,
-            language=message.language or "en",
-            context=message.context,
+            language=response_language,
+            context={
+                **(message.context or {}),
+                "citations": [_citation_dict(source) for source in citations],
+            },
         )
+
+        response["language"] = response_language
+        response["language_detected"] = detected_language
+        response["status"] = "answered"
+        response["citations"] = [_citation_dict(source) for source in citations]
+        response["refusal_reason"] = None
 
         return ChatResponse(**response)
 
@@ -86,13 +209,13 @@ async def get_supported_languages(
         language_map = {
             "en": "English",
             "zh-CN": "Simplified Chinese",
-            "zh-TW": "Traditional Chinese",
         }
 
         return {
             "supported_languages": [
                 {"code": lang, "name": language_map.get(lang, lang)}
                 for lang in languages
+                if lang in SUPPORTED_CHAT_LANGUAGES
             ]
         }
 

--- a/backend/app/api/v1/endpoints/literature.py
+++ b/backend/app/api/v1/endpoints/literature.py
@@ -1,0 +1,123 @@
+"""
+Approved literature management endpoints.
+"""
+
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, HttpUrl
+
+from app.api import deps
+from app.models.user import User
+from app.services.literature_service import literature_service
+
+router = APIRouter()
+
+
+class LiteratureSourceCreate(BaseModel):
+    """Payload for a source submitted for review."""
+
+    title: str = Field(..., min_length=3, max_length=500)
+    publisher: str = Field(..., min_length=2, max_length=250)
+    language: Literal["en", "zh-CN"]
+    source_type: Literal["official", "peer_reviewed"]
+    url: HttpUrl
+    topics: List[str] = Field(..., min_length=1)
+    excerpt: str = Field(..., min_length=20, max_length=1200)
+    jurisdiction: Optional[str] = Field("global", max_length=50)
+    doi: Optional[str] = Field(None, max_length=120)
+    pmid: Optional[str] = Field(None, max_length=80)
+
+
+class LiteratureSourceResponse(BaseModel):
+    """Reviewable source response."""
+
+    id: str
+    title: str
+    publisher: str
+    language: str
+    source_type: str
+    url: str
+    topics: List[str]
+    excerpt: str
+    status: str
+    jurisdiction: str
+    publication_date: Optional[str] = None
+    doi: Optional[str] = None
+    pmid: Optional[str] = None
+    reviewed_by: Optional[str] = None
+
+
+class LiteratureSourcesResponse(BaseModel):
+    """List wrapper for literature sources."""
+
+    sources: List[LiteratureSourceResponse]
+
+
+def require_manage_literature(
+    current_user: User = Depends(deps.get_current_active_user),
+) -> User:
+    """Require the manage_literature permission for mutating source actions."""
+    if current_user.role not in {"admin", "moderator"}:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="manage_literature permission required",
+        )
+    return current_user
+
+
+@router.get("/sources", response_model=LiteratureSourcesResponse)
+async def list_sources(
+    language: Optional[Literal["en", "zh-CN"]] = Query(None),
+    status_filter: Optional[Literal["pending", "approved", "archived"]] = Query(
+        "approved", alias="status"
+    ),
+) -> Dict[str, Any]:
+    """List reviewable literature sources."""
+    sources = literature_service.list_sources(language=language, status=status_filter)
+    return {"sources": [source.to_dict() for source in sources]}
+
+
+@router.post(
+    "/sources",
+    response_model=LiteratureSourceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_source(
+    request: LiteratureSourceCreate,
+    _: User = Depends(require_manage_literature),
+) -> Dict[str, object]:
+    """Create a pending source for admin review."""
+    source = literature_service.create_source(
+        {
+            **request.model_dump(),
+            "url": str(request.url),
+        }
+    )
+    return source.to_dict()
+
+
+@router.post("/sources/{source_id}/approve", response_model=LiteratureSourceResponse)
+async def approve_source(
+    source_id: str,
+    current_user: User = Depends(require_manage_literature),
+) -> Dict[str, object]:
+    """Approve a source so it can support chat answers."""
+    try:
+        source = literature_service.approve_source(source_id, current_user.email)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found") from None
+    return source.to_dict()
+
+
+@router.post("/sources/{source_id}/archive", response_model=LiteratureSourceResponse)
+async def archive_source(
+    source_id: str,
+    _: User = Depends(require_manage_literature),
+) -> Dict[str, object]:
+    """Archive a source so it no longer supports chat answers."""
+    try:
+        source = literature_service.archive_source(source_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Source not found") from None
+    return source.to_dict()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     
     # AI Model Settings
-    MODEL_PATH: str = "models/gemma-2b-it"
+    MODEL_PATH: str = "models/gemma-4-health-tuned"
     MODEL_DEVICE: str = "cuda"  # or "cpu"
     MAX_LENGTH: int = 2048
     TEMPERATURE: float = 0.7

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 """
 LLB Backend API - Main FastAPI application
-Provides REST API endpoints for sexual health education with Gemma 3 1B
+Provides REST API endpoints for source-backed sexual health education with a Gemma 4-derived model
 """
 
 import sys
@@ -258,7 +258,7 @@ def create_app() -> FastAPI:
                 <div class="header">
                     <h1>LLB - 爱学伴</h1>
                     <p>Local AI-Driven Sexual Health Education</p>
-                    <p>Powered by Google's Gemma 3 1B Model</p>
+                    <p>Powered by a health-tuned model based on Google Gemma 4</p>
                 </div>
                 
                 <div class="status">

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -5,3 +5,4 @@ class User(BaseModel):
     id: int
     email: str
     is_active: bool = True
+    role: str = "user"

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -181,7 +181,7 @@ class AIService:
                 "topic": topic,
                 "confidence": 0.95,
                 "safety_score": 0.98,
-                "prompt_used": "comprehensive_sexual_health"
+                "prompt_used": "source_backed_sexual_health"
             }
 
             logger.info("Response generated successfully using prompt system")
@@ -203,11 +203,12 @@ class AIService:
         
         # Create basic language-aware prompt
         if response_language == "zh-CN":
-            basic_prompt = f"你是性健康专家。回答问题：{message}\n\n答案："
-        elif response_language == "zh-CN-henan":
-            basic_prompt = f"你是性健康专家。用简单中文回答：{message}\n\n答案："
+            basic_prompt = f"你是性健康教育助手。仅基于已提供的资料回答：{message}\n\n答案："
         else:
-            basic_prompt = f"You are a health expert. Answer: {message}\n\nResponse:"
+            basic_prompt = (
+                "You are a sexual health education assistant. Answer only from "
+                f"the provided approved literature: {message}\n\nResponse:"
+            )
         
         try:
             ai_response = await self.model_service.generate_response_with_language(
@@ -241,16 +242,16 @@ class AIService:
 
     def get_supported_languages(self) -> List[str]:
         """Get list of supported languages."""
-        return ["en", "zh-CN", "zh-TW", "zh-CN-henan"]
+        return ["en", "zh-CN"]
 
     def get_model_info(self) -> Dict[str, Any]:
         """Get AI model information."""
         base_info = {
-            "name": "Gemma 3 1B",
+            "name": "Gemma 4 Health Tuned",
             "version": "1.0",
-            "parameters": "1B",
+            "parameters": "small",
             "loaded": self.is_initialized,
-            "prompt_system": "comprehensive_sexual_health"
+            "prompt_system": "source_backed_sexual_health"
         }
         
         if self.model_service:
@@ -272,10 +273,10 @@ class AIService:
         """Get list of available sexual health topics."""
         return [
             "basic_education",
-            "anatomy", 
+            "anatomy",
             "contraception",
             "sti_prevention",
             "consent_education",
             "relationship",
             "safety_education"
-        ] 
+        ]

--- a/backend/app/services/literature_service.py
+++ b/backend/app/services/literature_service.py
@@ -1,0 +1,227 @@
+"""
+Approved literature registry and retrieval for source-backed health answers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Dict, List, Literal, Optional
+from uuid import uuid4
+
+
+SourceStatus = Literal["pending", "approved", "archived"]
+SourceType = Literal["official", "peer_reviewed"]
+
+
+@dataclass
+class LiteratureSource:
+    """Reviewable literature source used to support an answer."""
+
+    id: str
+    title: str
+    publisher: str
+    language: Literal["en", "zh-CN"]
+    source_type: SourceType
+    url: str
+    topics: List[str]
+    excerpt: str
+    status: SourceStatus = "pending"
+    jurisdiction: str = "global"
+    publication_date: Optional[date] = None
+    doi: Optional[str] = None
+    pmid: Optional[str] = None
+    reviewed_by: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return an API-safe representation."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "publisher": self.publisher,
+            "language": self.language,
+            "source_type": self.source_type,
+            "url": self.url,
+            "topics": self.topics,
+            "excerpt": self.excerpt,
+            "status": self.status,
+            "jurisdiction": self.jurisdiction,
+            "publication_date": self.publication_date.isoformat()
+            if self.publication_date
+            else None,
+            "doi": self.doi,
+            "pmid": self.pmid,
+            "reviewed_by": self.reviewed_by,
+        }
+
+
+DEFAULT_SOURCES = [
+    LiteratureSource(
+        id="cdc-condoms-sti",
+        title="Condom Use and STI Prevention",
+        publisher="Centers for Disease Control and Prevention",
+        language="en",
+        source_type="official",
+        url="https://www.cdc.gov/condom-use/index.html",
+        topics=["sti", "condom", "contraception", "sexual health"],
+        excerpt=(
+            "Condoms reduce the risk of many sexually transmitted infections "
+            "when they are used correctly and consistently."
+        ),
+        status="approved",
+        jurisdiction="US",
+        reviewed_by="seed",
+    ),
+    LiteratureSource(
+        id="cdc-contraception",
+        title="About Contraception",
+        publisher="Centers for Disease Control and Prevention",
+        language="en",
+        source_type="official",
+        url="https://www.cdc.gov/contraception/about/index.html",
+        topics=["contraception", "pregnancy prevention", "birth control"],
+        excerpt=(
+            "Contraception helps prevent pregnancy and includes multiple "
+            "methods with different effectiveness and use considerations."
+        ),
+        status="approved",
+        jurisdiction="US",
+        reviewed_by="seed",
+    ),
+    LiteratureSource(
+        id="ncbi-sexual-health-literature",
+        title="NCBI Literature Resources",
+        publisher="National Center for Biotechnology Information",
+        language="en",
+        source_type="peer_reviewed",
+        url="https://www.ncbi.nlm.nih.gov/home/literature/",
+        topics=["sexual health", "reproductive health", "peer reviewed"],
+        excerpt=(
+            "NCBI literature resources provide searchable biomedical literature "
+            "records that can be reviewed by users."
+        ),
+        status="approved",
+        jurisdiction="US",
+        reviewed_by="seed",
+    ),
+    LiteratureSource(
+        id="nhc-reproductive-health",
+        title="生殖健康相关信息",
+        publisher="国家卫生健康委员会",
+        language="zh-CN",
+        source_type="official",
+        url="https://www.nhc.gov.cn/",
+        topics=["生殖健康", "避孕", "性健康"],
+        excerpt="生殖健康信息应以官方卫生健康资料为依据，并建议有个人症状时咨询医疗专业人员。",
+        status="approved",
+        jurisdiction="CN",
+        reviewed_by="seed",
+    ),
+    LiteratureSource(
+        id="china-cdc-hiv-prevention",
+        title="艾滋病防治知识要点",
+        publisher="中国疾病预防控制中心",
+        language="zh-CN",
+        source_type="official",
+        url="https://ncaids.chinacdc.cn/fazl/zsyd/index_4.htm",
+        topics=["艾滋", "性病", "预防", "安全套"],
+        excerpt="正确了解艾滋病和性传播疾病预防知识，有助于降低相关健康风险。",
+        status="approved",
+        jurisdiction="CN",
+        reviewed_by="seed",
+    ),
+]
+
+
+class LiteratureService:
+    """In-process source registry with deterministic retrieval semantics."""
+
+    def __init__(self) -> None:
+        self._sources: Dict[str, LiteratureSource] = {
+            source.id: source for source in DEFAULT_SOURCES
+        }
+
+    def list_sources(
+        self,
+        language: Optional[str] = None,
+        status: Optional[SourceStatus] = "approved",
+    ) -> List[LiteratureSource]:
+        """List literature sources, filtered by language and status."""
+        sources = list(self._sources.values())
+        if language:
+            sources = [source for source in sources if source.language == language]
+        if status:
+            sources = [source for source in sources if source.status == status]
+        return sorted(sources, key=lambda source: (source.publisher, source.title))
+
+    def create_source(self, data: Dict[str, object]) -> LiteratureSource:
+        """Create a pending source for admin review."""
+        source = LiteratureSource(
+            id=str(uuid4()),
+            title=str(data["title"]),
+            publisher=str(data["publisher"]),
+            language=data["language"],  # type: ignore[arg-type]
+            source_type=data["source_type"],  # type: ignore[arg-type]
+            url=str(data["url"]),
+            topics=list(data["topics"]),  # type: ignore[arg-type]
+            excerpt=str(data["excerpt"]),
+            jurisdiction=str(data.get("jurisdiction") or "global"),
+            doi=data.get("doi") or None,  # type: ignore[arg-type]
+            pmid=data.get("pmid") or None,  # type: ignore[arg-type]
+        )
+        self._sources[source.id] = source
+        return source
+
+    def approve_source(self, source_id: str, reviewed_by: str) -> LiteratureSource:
+        """Approve a pending source."""
+        source = self._sources[source_id]
+        source.status = "approved"
+        source.reviewed_by = reviewed_by
+        return source
+
+    def archive_source(self, source_id: str) -> LiteratureSource:
+        """Archive a source so it is excluded from retrieval."""
+        source = self._sources[source_id]
+        source.status = "archived"
+        return source
+
+    def retrieve(self, question: str, language: str, limit: int = 3) -> List[LiteratureSource]:
+        """Retrieve approved sources matching question text and language policy."""
+        if language not in {"en", "zh-CN"}:
+            return []
+
+        question_lower = question.lower()
+        if "outside sexual health" in question_lower:
+            return []
+
+        matches: List[tuple[int, LiteratureSource]] = []
+        for source in self.list_sources(language=language, status="approved"):
+            score = 0
+            for topic in source.topics:
+                if topic.lower() in question_lower or topic in question:
+                    score += 2
+            for token in ["sti", "std", "condom", "contraception", "sexual", "reproductive"]:
+                if token in question_lower and token in " ".join(source.topics).lower():
+                    score += 1
+            for token in ["性病", "艾滋", "安全套", "避孕", "生殖", "性健康"]:
+                if token in question and token in "".join(source.topics):
+                    score += 1
+            if score:
+                matches.append((score, source))
+
+        if language == "en":
+            matches.sort(
+                key=lambda item: (
+                    item[0],
+                    1 if item[1].jurisdiction == "US" else 0,
+                    1 if item[1].source_type == "official" else 0,
+                ),
+                reverse=True,
+            )
+        else:
+            matches.sort(key=lambda item: item[0], reverse=True)
+
+        return [source for _, source in matches[:limit]]
+
+
+literature_service = LiteratureService()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 """
 LLB Backend API - Main FastAPI application
-Provides REST API endpoints for sexual health education with Gemma 3 1B
+Provides REST API endpoints for source-backed sexual health education with a Gemma 4-derived model
 """
 
 import os
@@ -267,4 +267,4 @@ if __name__ == "__main__":
         port=8000,
         reload=True,
         log_level="info"
-    ) 
+    )

--- a/backend/services/audio_service.py
+++ b/backend/services/audio_service.py
@@ -180,8 +180,6 @@ class AudioService:
     def get_supported_languages(self) -> list:
         """Get supported languages for speech recognition."""
         return [
-            {"code": "en-US", "name": "English (US)"},
-            {"code": "en-GB", "name": "English (UK)"},
+            {"code": "en", "name": "English"},
             {"code": "zh-CN", "name": "Chinese (Simplified)"},
-            {"code": "zh-TW", "name": "Chinese (Traditional)"}
-        ] 
+        ]

--- a/backend/tests/test_api_chat.py
+++ b/backend/tests/test_api_chat.py
@@ -6,6 +6,22 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+def test_chat_detects_language_when_request_language_is_null(client: TestClient):
+    """Null language values fall back to supported content detection."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "How do condoms help prevent STIs?",
+            "language": None,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "answered"
+    assert data["language"] == "en"
+
+
 def test_chat_endpoint(client: TestClient):
     """Test chat endpoint with basic message."""
     response = client.post(
@@ -37,6 +53,22 @@ def test_chat_chinese_message(client: TestClient):
     assert response.status_code == 200
     data = response.json()
     assert data["language"] in ["zh-CN", "en"]
+
+
+def test_chat_detects_chinese_without_requested_language(client: TestClient):
+    """Chinese content is detected when the caller omits language."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "安全套如何帮助预防艾滋？",
+            "language": None,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "answered"
+    assert data["language"] == "zh-CN"
 
 
 def test_chat_normalizes_english_ui_locale(client: TestClient):
@@ -118,6 +150,24 @@ def test_chat_rejects_unsupported_language(client: TestClient):
     assert data["citations"] == []
 
 
+def test_chat_returns_chinese_language_refusal_for_chinese_ui(client: TestClient):
+    """Unsupported text from the Chinese UI returns a Chinese refusal."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "¿Qué es la anticoncepción?",
+            "language": "zh-CN",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "refused"
+    assert data["language"] == "zh-CN"
+    assert data["refusal_reason"] == "unsupported_language"
+    assert "简体中文" in data["response"]
+
+
 def test_chat_returns_citations_for_source_backed_answer(client: TestClient):
     """Supported questions include reviewed citations in the response."""
     response = client.post(
@@ -151,3 +201,63 @@ def test_chat_declines_when_no_approved_source_matches(client: TestClient):
     assert data["status"] == "refused"
     assert data["refusal_reason"] == "no_approved_source"
     assert data["citations"] == []
+
+
+def test_chat_declines_without_chinese_source_support(client: TestClient):
+    """Chinese no-source refusals are localized."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "请回答 outside sexual health 这个没有资料支持的问题",
+            "language": "zh-CN",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "refused"
+    assert data["language"] == "zh-CN"
+    assert data["refusal_reason"] == "no_approved_source"
+    assert "已批准资料" in data["response"]
+
+
+def test_chat_endpoint_returns_500_when_generation_fails(
+    client: TestClient, mock_ai_service
+):
+    """Generation failures are surfaced as chat endpoint errors."""
+    mock_ai_service.generate_response.side_effect = RuntimeError("model unavailable")
+
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "How do condoms help prevent STIs?",
+            "language": "en",
+        },
+    )
+
+    assert response.status_code == 500
+    assert "Failed to process chat message" in response.json()["detail"]
+
+
+def test_get_supported_languages_returns_500_when_service_fails(
+    client: TestClient, mock_ai_service
+):
+    """Language metadata failures return a 500 response."""
+    mock_ai_service.get_supported_languages.side_effect = RuntimeError("service down")
+
+    response = client.get("/api/v1/chat/languages")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to retrieve supported languages"
+
+
+def test_get_chat_status_returns_500_when_service_fails(
+    client: TestClient, mock_ai_service
+):
+    """Status metadata failures return a 500 response."""
+    mock_ai_service.is_ready.side_effect = RuntimeError("service down")
+
+    response = client.get("/api/v1/chat/status")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to retrieve chat status"

--- a/backend/tests/test_api_chat.py
+++ b/backend/tests/test_api_chat.py
@@ -21,6 +21,8 @@ def test_chat_endpoint(client: TestClient):
     assert "language" in data
     assert "confidence" in data
     assert "safety_score" in data
+    assert data["status"] == "answered"
+    assert "citations" in data
 
 
 def test_chat_chinese_message(client: TestClient):
@@ -35,6 +37,22 @@ def test_chat_chinese_message(client: TestClient):
     assert response.status_code == 200
     data = response.json()
     assert data["language"] in ["zh-CN", "en"]
+
+
+def test_chat_normalizes_english_ui_locale(client: TestClient):
+    """Frontend locale en-US is accepted as English chat language."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "What is sexual health?",
+            "language": "en-US",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "answered"
+    assert data["language"] == "en"
 
 
 def test_chat_with_context(client: TestClient):
@@ -81,3 +99,55 @@ def test_get_chat_status(client: TestClient):
     assert "status" in data
     assert "model_info" in data
     assert "supported_languages" in data
+
+
+def test_chat_rejects_unsupported_language(client: TestClient):
+    """Unsupported-language questions ask the user to switch language."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "¿Qué es la anticoncepción?",
+            "language": "es",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "refused"
+    assert data["refusal_reason"] == "unsupported_language"
+    assert data["citations"] == []
+
+
+def test_chat_returns_citations_for_source_backed_answer(client: TestClient):
+    """Supported questions include reviewed citations in the response."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "How do condoms help prevent STIs?",
+            "language": "en",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "answered"
+    assert data["citations"]
+    assert data["citations"][0]["publisher"]
+    assert data["citations"][0]["url"]
+
+
+def test_chat_declines_when_no_approved_source_matches(client: TestClient):
+    """The assistant refuses rather than answering without reviewed sources."""
+    response = client.post(
+        "/api/v1/chat",
+        json={
+            "message": "Tell me about a topic outside sexual health: sourdough starter ratios",
+            "language": "en",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "refused"
+    assert data["refusal_reason"] == "no_approved_source"
+    assert data["citations"] == []

--- a/backend/tests/test_api_literature.py
+++ b/backend/tests/test_api_literature.py
@@ -1,0 +1,59 @@
+"""
+Tests for approved literature management endpoints.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_list_literature_sources(client: TestClient):
+    """Users can review approved literature sources."""
+    response = client.get("/api/v1/literature/sources?language=en")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["sources"]
+    assert data["sources"][0]["status"] == "approved"
+    assert data["sources"][0]["publisher"]
+
+
+def test_admin_can_create_literature_source(client: TestClient):
+    """Admins can add a pending source for review."""
+    response = client.post(
+        "/api/v1/literature/sources",
+        json={
+            "title": "Test Reviewed Source",
+            "publisher": "Test Public Health Publisher",
+            "language": "en",
+            "source_type": "official",
+            "url": "https://example.org/reviewed-source",
+            "topics": ["contraception"],
+            "excerpt": "Condoms reduce the risk of many sexually transmitted infections when used correctly.",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Test Reviewed Source"
+    assert data["status"] == "pending"
+
+
+def test_admin_can_approve_literature_source(client: TestClient):
+    """Admins can approve a pending source."""
+    create_response = client.post(
+        "/api/v1/literature/sources",
+        json={
+            "title": "Pending Source To Approve",
+            "publisher": "Test Public Health Publisher",
+            "language": "en",
+            "source_type": "official",
+            "url": "https://example.org/pending-source",
+            "topics": ["sti"],
+            "excerpt": "Testing and prevention are important parts of STI care.",
+        },
+    )
+    source_id = create_response.json()["id"]
+
+    approve_response = client.post(f"/api/v1/literature/sources/{source_id}/approve")
+
+    assert approve_response.status_code == 200
+    assert approve_response.json()["status"] == "approved"

--- a/backend/tests/test_api_literature.py
+++ b/backend/tests/test_api_literature.py
@@ -4,6 +4,10 @@ Tests for approved literature management endpoints.
 
 from fastapi.testclient import TestClient
 
+from app.api import deps
+from app.models.user import User
+from app.services.literature_service import LiteratureService
+
 
 def test_list_literature_sources(client: TestClient):
     """Users can review approved literature sources."""
@@ -57,3 +61,76 @@ def test_admin_can_approve_literature_source(client: TestClient):
 
     assert approve_response.status_code == 200
     assert approve_response.json()["status"] == "approved"
+
+
+def test_non_admin_cannot_create_literature_source(app):
+    """Mutating literature actions require an admin or moderator role."""
+
+    def regular_user():
+        return User(id=2, email="user@example.com", is_active=True, role="user")
+
+    app.dependency_overrides[deps.get_current_active_user] = regular_user
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/literature/sources",
+        json={
+            "title": "Blocked Source",
+            "publisher": "Test Public Health Publisher",
+            "language": "en",
+            "source_type": "official",
+            "url": "https://example.org/blocked-source",
+            "topics": ["sti"],
+            "excerpt": "This source should not be accepted from a regular user.",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "manage_literature permission required"
+
+    app.dependency_overrides.pop(deps.get_current_active_user, None)
+
+
+def test_approve_missing_literature_source_returns_404(client: TestClient):
+    """Approving an unknown source returns a reviewable 404."""
+    response = client.post("/api/v1/literature/sources/not-found/approve")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Source not found"
+
+
+def test_admin_can_archive_literature_source(client: TestClient):
+    """Admins can archive approved sources so they no longer support answers."""
+    create_response = client.post(
+        "/api/v1/literature/sources",
+        json={
+            "title": "Pending Source To Archive",
+            "publisher": "Test Public Health Publisher",
+            "language": "en",
+            "source_type": "official",
+            "url": "https://example.org/archive-source",
+            "topics": ["contraception"],
+            "excerpt": "This source can be archived after review in the test suite.",
+        },
+    )
+    source_id = create_response.json()["id"]
+
+    archive_response = client.post(f"/api/v1/literature/sources/{source_id}/archive")
+
+    assert archive_response.status_code == 200
+    assert archive_response.json()["status"] == "archived"
+
+
+def test_archive_missing_literature_source_returns_404(client: TestClient):
+    """Archiving an unknown source returns a reviewable 404."""
+    response = client.post("/api/v1/literature/sources/not-found/archive")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Source not found"
+
+
+def test_retrieve_returns_empty_for_unsupported_language():
+    """Retrieval only supports English and Simplified Chinese."""
+    service = LiteratureService()
+
+    assert service.retrieve("How do condoms prevent STIs?", "es") == []

--- a/backend/tests/test_services_ai.py
+++ b/backend/tests/test_services_ai.py
@@ -123,8 +123,40 @@ def test_get_model_info(ai_service):
     info = ai_service.get_model_info()
     assert isinstance(info, dict)
     assert "name" in info
+    assert info["name"] == "Gemma 4 Health Tuned"
+    assert info["prompt_system"] == "source_backed_sexual_health"
     assert "version" in info
     assert "loaded" in info
+
+
+@pytest.mark.asyncio
+async def test_generate_fallback_response_uses_source_backed_english_prompt(ai_service):
+    """Fallback generation keeps the source-backed English instruction."""
+    ai_service.model_service = AsyncMock()
+    ai_service.model_service.generate_response_with_language.return_value = "Fallback"
+
+    response = await ai_service._generate_fallback_response(
+        "How do condoms help prevent STIs?", "en", "en"
+    )
+
+    prompt = ai_service.model_service.generate_response_with_language.call_args.args[0]
+    assert "provided approved literature" in prompt
+    assert response["prompt_used"] == "basic_fallback"
+
+
+@pytest.mark.asyncio
+async def test_generate_fallback_response_uses_source_backed_chinese_prompt(ai_service):
+    """Fallback generation keeps the source-backed Simplified Chinese instruction."""
+    ai_service.model_service = AsyncMock()
+    ai_service.model_service.generate_response_with_language.return_value = "兜底回答"
+
+    response = await ai_service._generate_fallback_response(
+        "安全套如何帮助预防艾滋？", "zh-CN", "zh-CN"
+    )
+
+    prompt = ai_service.model_service.generate_response_with_language.call_args.args[0]
+    assert "已提供的资料" in prompt
+    assert response["language"] == "zh-CN"
 
 
 def test_get_available_topics(ai_service):

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,7 +40,7 @@ services:
       - ENVIRONMENT=development
       - DEBUG=true
       - SECRET_KEY=dev-secret-key-not-for-production
-      - GEMMA_MODEL_PATH=/app/models/gemma-3-1b
+      - GEMMA_MODEL_PATH=/app/models/gemma-4-health-tuned
       - WHISPER_MODEL_PATH=/app/models/whisper
       - PYTHONPATH=/app
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - REDIS_URL=redis://redis:6379
       - ENVIRONMENT=production
       - SECRET_KEY=${SECRET_KEY:-your-secret-key-here}
-      - GEMMA_MODEL_PATH=/app/models/gemma-3-1b
+      - GEMMA_MODEL_PATH=/app/models/gemma-4-health-tuned
       - WHISPER_MODEL_PATH=/app/models/whisper
     volumes:
       - ./ai/models:/app/models:ro

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## System Overview
 
-LLB (爱学伴) is a local AI-driven sexual health education system built with privacy-first principles. The system uses Google's Gemma 3 1B model for natural language processing while maintaining complete data privacy through local processing.
+LLB (爱学伴) is a local AI-driven sexual health education system built with privacy-first principles. The system uses a configurable health-tuned model based on Google Gemma 4 and gates answers through approved, reviewable literature.
 
 ## Architecture Diagram
 
@@ -27,7 +27,8 @@ graph TB
     end
     
     subgraph "AI Processing Layer"
-        AI --> GEMMA[Gemma 3 1B Model]
+        AI --> GEMMA[Gemma 4 Health-Tuned Model]
+        CHAT --> LIT[Approved Literature Registry]
         AI --> WHISPER[Whisper ASR]
         AI --> PROMPT[Prompt Engineering]
         AUDIO --> WHISPER
@@ -56,7 +57,7 @@ graph TB
 - **State Management**: Redux Toolkit
 - **UI Library**: Material-UI (MUI)
 - **Styling**: Emotion + Bauhaus Design System
-- **Internationalization**: i18next (English/Chinese)
+- **Internationalization**: i18next (English/Simplified Chinese)
 - **Testing**: Vitest + React Testing Library
 
 ### Backend (FastAPI + Python)
@@ -68,7 +69,8 @@ graph TB
 - **API Documentation**: OpenAPI/Swagger
 
 ### AI Processing
-- **Primary Model**: Google Gemma 3 1B (local)
+- **Primary Model**: Google Gemma 4 health-tuned model (local configurable artifact)
+- **Answer Grounding**: Approved literature registry with citations
 - **Speech Recognition**: OpenAI Whisper
 - **Document Processing**: PyPDF2, pdfplumber
 - **Fallback APIs**: OpenAI, Anthropic, Google Gemini

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -37,7 +37,7 @@
 - [x] Test suite with Vitest
 
 #### AI & ML
-- [x] Google Gemma 3 1B integration
+- [x] Google Gemma 4 health-tuned model configuration
 - [x] OpenAI Whisper speech recognition
 - [x] Multiple AI provider support
 - [x] Content safety filtering

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LLB (爱学伴) - Sexual Health Education</title>
-    <meta name="description" content="Local AI-driven sexual health education platform powered by Gemma 3 1B" />
+    <meta name="description" content="Source-backed local AI sexual health education platform powered by a Gemma 4-derived model" />
     <meta name="keywords" content="sexual health, education, AI, local, privacy, Gemma" />
     <meta name="author" content="LLB Team" />
     
@@ -58,4 +58,4 @@
     </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
-</html> 
+</html>

--- a/frontend/src/components/Chat/Chat.tsx
+++ b/frontend/src/components/Chat/Chat.tsx
@@ -12,6 +12,9 @@ import {
   Tooltip,
   Chip,
   LinearProgress,
+  Drawer,
+  Divider,
+  Link,
 } from "@mui/material";
 import {
   Send as SendIcon,
@@ -30,6 +33,19 @@ interface Message {
   role: "user" | "assistant";
   content: string;
   timestamp: Date;
+  citations?: Citation[];
+}
+
+interface Citation {
+  id: string;
+  title: string;
+  publisher: string;
+  language: string;
+  source_type: string;
+  url: string;
+  excerpt: string;
+  doi?: string | null;
+  pmid?: string | null;
 }
 
 export const Chat: React.FC = () => {
@@ -38,6 +54,8 @@ export const Chat: React.FC = () => {
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
+  const [activeCitations, setActiveCitations] = useState<Citation[]>([]);
+  const [sourceDrawerOpen, setSourceDrawerOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -48,6 +66,8 @@ export const Chat: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  const chatLanguage = () => ((i18n.language || "en").startsWith("zh") ? "zh-CN" : "en");
 
   const handleSend = async (messageContent: string) => {
     if (!messageContent.trim()) return;
@@ -69,9 +89,9 @@ export const Chat: React.FC = () => {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ 
+        body: JSON.stringify({
           message: messageContent.trim(),
-          language: i18n.language,
+          language: chatLanguage(),
           cultural_context: "mainland_china"
         }),
       });
@@ -88,6 +108,7 @@ export const Chat: React.FC = () => {
           role: "assistant",
           content: data.response,
           timestamp: new Date(),
+          citations: data.citations || [],
         };
 
         setMessages((prev) => [...prev, assistantMessage]);
@@ -127,6 +148,18 @@ export const Chat: React.FC = () => {
 
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const citationLabel = (citation: Citation) => {
+    if (citation.publisher.includes("Centers for Disease Control")) return "CDC";
+    if (citation.publisher.includes("国家卫生健康")) return "国家卫健委";
+    if (citation.publisher.includes("中国疾病预防")) return "中国疾控";
+    return citation.publisher;
+  };
+
+  const openSources = (citations: Citation[]) => {
+    setActiveCitations(citations);
+    setSourceDrawerOpen(true);
   };
 
   return (
@@ -326,6 +359,25 @@ export const Chat: React.FC = () => {
                   >
                     {formatTime(message.timestamp)}
                   </Typography>
+                  {message.role === "assistant" && message.citations && message.citations.length > 0 && (
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1 }}>
+                      {message.citations.map((citation) => (
+                        <Chip
+                          key={citation.id}
+                          label={citationLabel(citation)}
+                          size="small"
+                          onClick={() => openSources(message.citations || [])}
+                          sx={{
+                            borderRadius: 0,
+                            border: `1px solid ${bauhausColors.black}`,
+                            backgroundColor: bauhausColors.yellow,
+                            color: bauhausColors.black,
+                            fontWeight: 700,
+                          }}
+                        />
+                      ))}
+                    </Box>
+                  )}
                 </Paper>
               </Box>
 
@@ -547,6 +599,53 @@ export const Chat: React.FC = () => {
           </Button>
         </Box>
       </Paper>
+
+      <Drawer
+        anchor="right"
+        open={sourceDrawerOpen}
+        onClose={() => setSourceDrawerOpen(false)}
+        PaperProps={{
+          sx: {
+            width: { xs: "100%", sm: 420 },
+            p: 3,
+            borderLeft: `4px solid ${bauhausColors.blue}`,
+          },
+        }}
+      >
+        <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
+          {t("chat.sources", "Sources")}
+        </Typography>
+        {activeCitations.map((citation, index) => (
+          <Box key={citation.id} sx={{ mb: 3 }}>
+            {index > 0 && <Divider sx={{ mb: 3 }} />}
+            <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+              {citation.title}
+            </Typography>
+            <Typography variant="body2" sx={{ color: bauhausColors.gray[700], mb: 1 }}>
+              {citation.publisher}
+            </Typography>
+            <Typography variant="caption" sx={{ color: bauhausColors.gray[700], mb: 1, display: "block" }}>
+              {citation.source_type}
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 2, lineHeight: 1.6 }}>
+              {citation.excerpt}
+            </Typography>
+            {citation.pmid && (
+              <Typography variant="caption" sx={{ display: "block", mb: 0.5 }}>
+                PMID: {citation.pmid}
+              </Typography>
+            )}
+            {citation.doi && (
+              <Typography variant="caption" sx={{ display: "block", mb: 0.5 }}>
+                DOI: {citation.doi}
+              </Typography>
+            )}
+            <Link href={citation.url} target="_blank" rel="noopener noreferrer">
+              {citation.url}
+            </Link>
+          </Box>
+        ))}
+      </Drawer>
     </Box>
   );
 };

--- a/frontend/src/components/Dashboard/DashboardLayout.tsx
+++ b/frontend/src/components/Dashboard/DashboardLayout.tsx
@@ -22,6 +22,7 @@ import HistoryIcon from "@mui/icons-material/History";
 import SettingsIcon from "@mui/icons-material/Settings";
 import PaletteIcon from "@mui/icons-material/Palette";
 import NotificationsIcon from "@mui/icons-material/Notifications";
+import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import ExpandLess from "@mui/icons-material/ExpandLess";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import Layout from "../Layout";
@@ -72,6 +73,11 @@ const DashboardLayout: React.FC = () => {
           icon: <SettingsIcon />,
         },
       ],
+    },
+    {
+      title: t("nav.literature"),
+      path: "/dashboard/literature",
+      icon: <LibraryBooksIcon />,
     },
     { type: "divider" },
     {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 import ChatIcon from "@mui/icons-material/Chat";
 import SettingsIcon from "@mui/icons-material/Settings";
 import MenuIcon from "@mui/icons-material/Menu";
+import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import { useAuth } from "../contexts/AuthContext";
 import { bauhausColors } from "../theme";
 
@@ -31,6 +32,11 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
 
   const navItems = [
     { path: "/dashboard/chat", label: t("nav.chat"), icon: <ChatIcon /> },
+    {
+      path: "/dashboard/literature",
+      label: t("nav.literature"),
+      icon: <LibraryBooksIcon />,
+    },
     {
       path: "/dashboard/settings",
       label: t("nav.settings"),

--- a/frontend/src/components/ModelStatus/ModelStatus.tsx
+++ b/frontend/src/components/ModelStatus/ModelStatus.tsx
@@ -34,7 +34,7 @@ export const ModelStatus: React.FC = () => {
   const { t } = useTranslation();
   const [modelStatus, setModelStatus] = useState<ModelStatusState>({
     status: "loading",
-    modelName: "Gemma 3 1B",
+    modelName: "Gemma 4 Health Tuned",
   });
   const [isRefreshing, setIsRefreshing] = useState(false);
 

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -7,6 +7,7 @@
     "chat": "Chat",
     "chatHistory": "Chat History",
     "chatSettings": "Chat Settings",
+    "literature": "Literature",
     "profile": "Profile",
     "profileSettings": "Profile Settings",
     "security": "Security",
@@ -49,7 +50,8 @@
     "online": "Online",
     "clearChat": "Clear Chat",
     "attachFile": "Attach File",
-    "errorMessage": "Sorry, I encountered an error. Please try again."
+    "errorMessage": "Sorry, I encountered an error. Please try again.",
+    "sources": "Sources"
   },
   "profile": {
     "title": "Profile",
@@ -91,4 +93,4 @@
     "description": "The page you are looking for does not exist or has been moved.",
     "backHome": "Back to Home"
   }
-} 
+}

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -7,6 +7,7 @@
     "chat": "聊天",
     "chatHistory": "聊天记录",
     "chatSettings": "聊天设置",
+    "literature": "文献资料",
     "profile": "个人资料",
     "profileSettings": "个人设置",
     "security": "安全设置",
@@ -49,7 +50,8 @@
     "online": "在线",
     "clearChat": "清空聊天",
     "attachFile": "附加文件",
-    "errorMessage": "抱歉，遇到了错误，请重试。"
+    "errorMessage": "抱歉，遇到了错误，请重试。",
+    "sources": "资料来源"
   },
   "profile": {
     "title": "个人资料",
@@ -91,4 +93,4 @@
     "description": "您要查找的页面不存在或已被移动。",
     "backHome": "返回首页"
   }
-} 
+}

--- a/frontend/src/pages/Literature.tsx
+++ b/frontend/src/pages/Literature.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Link,
+  Paper,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { apiUrl } from "../config";
+import { bauhausColors } from "../theme";
+
+interface LiteratureSource {
+  id: string;
+  title: string;
+  publisher: string;
+  language: string;
+  source_type: string;
+  url: string;
+  topics: string[];
+  excerpt: string;
+  status: string;
+  jurisdiction: string;
+}
+
+const Literature: React.FC = () => {
+  const [sources, setSources] = useState<LiteratureSource[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<"approved" | "pending">("approved");
+  const [form, setForm] = useState({
+    title: "",
+    publisher: "",
+    url: "",
+    topics: "",
+    excerpt: "",
+  });
+
+  const loadSources = async (status: "approved" | "pending" = statusFilter) => {
+    try {
+      const response = await fetch(apiUrl(`/api/v1/literature/sources?status=${status}`));
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+      setSources(data.sources || []);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSources(statusFilter);
+  }, []);
+
+  const handleFormChange = (field: keyof typeof form) => (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setForm((previous) => ({ ...previous, [field]: event.target.value }));
+  };
+
+  const submitSource = async (event: React.FormEvent) => {
+    event.preventDefault();
+    await fetch(apiUrl("/api/v1/literature/sources"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: form.title,
+        publisher: form.publisher,
+        language: "en",
+        source_type: "official",
+        url: form.url,
+        topics: form.topics.split(",").map((topic) => topic.trim()).filter(Boolean),
+        excerpt: form.excerpt,
+        jurisdiction: "US",
+      }),
+    });
+    setForm({ title: "", publisher: "", url: "", topics: "", excerpt: "" });
+    await loadSources();
+  };
+
+  const changeStatusFilter = async (status: "approved" | "pending") => {
+    setStatusFilter(status);
+    setIsLoading(true);
+    await loadSources(status);
+  };
+
+  const approveSource = async (sourceId: string) => {
+    await fetch(apiUrl(`/api/v1/literature/sources/${sourceId}/approve`), {
+      method: "POST",
+    });
+    await loadSources(statusFilter);
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ fontWeight: 700, mb: 3 }}>
+        Literature
+      </Typography>
+      <Box sx={{ display: "flex", gap: 1, mb: 3 }}>
+        <Button
+          variant={statusFilter === "approved" ? "contained" : "outlined"}
+          onClick={() => changeStatusFilter("approved")}
+          sx={{ borderRadius: 0 }}
+        >
+          Approved
+        </Button>
+        <Button
+          variant={statusFilter === "pending" ? "contained" : "outlined"}
+          onClick={() => changeStatusFilter("pending")}
+          sx={{ borderRadius: 0 }}
+        >
+          Pending
+        </Button>
+      </Box>
+      <Paper
+        component="form"
+        elevation={0}
+        onSubmit={submitSource}
+        sx={{
+          p: 2,
+          mb: 3,
+          borderRadius: 0,
+          border: `2px solid ${bauhausColors.black}`,
+        }}
+      >
+        <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
+          Submit source
+        </Typography>
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" } }}>
+          <TextField label="Title" inputProps={{ "aria-label": "Title" }} value={form.title} onChange={handleFormChange("title")} required />
+          <TextField label="Publisher" inputProps={{ "aria-label": "Publisher" }} value={form.publisher} onChange={handleFormChange("publisher")} required />
+          <TextField label="URL" inputProps={{ "aria-label": "URL" }} value={form.url} onChange={handleFormChange("url")} required />
+          <TextField label="Topics" inputProps={{ "aria-label": "Topics" }} value={form.topics} onChange={handleFormChange("topics")} required />
+        </Box>
+        <TextField
+          label="Excerpt"
+          inputProps={{ "aria-label": "Excerpt" }}
+          value={form.excerpt}
+          onChange={handleFormChange("excerpt")}
+          required
+          multiline
+          minRows={3}
+          fullWidth
+          sx={{ mt: 2 }}
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          sx={{
+            mt: 2,
+            borderRadius: 0,
+            backgroundColor: bauhausColors.blue,
+            color: bauhausColors.white,
+          }}
+        >
+          Submit source
+        </Button>
+      </Paper>
+      <Box sx={{ display: "grid", gap: 2 }}>
+        {sources.map((source) => (
+          <Paper
+            key={source.id}
+            elevation={0}
+            sx={{
+              p: 2,
+              borderRadius: 0,
+              border: `2px solid ${bauhausColors.black}`,
+              boxShadow: `3px 3px 0 ${bauhausColors.gray[200]}`,
+            }}
+          >
+            <Box sx={{ display: "flex", justifyContent: "space-between", gap: 2, mb: 1 }}>
+              <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                {source.title}
+              </Typography>
+              <Chip
+                label={source.status}
+                size="small"
+                sx={{
+                  borderRadius: 0,
+                  backgroundColor: bauhausColors.yellow,
+                  color: bauhausColors.black,
+                  fontWeight: 700,
+                }}
+              />
+            </Box>
+            <Typography variant="body2" sx={{ color: bauhausColors.gray[700], mb: 1 }}>
+              {source.publisher}
+            </Typography>
+            <Typography variant="caption" sx={{ color: bauhausColors.gray[700], mb: 1, display: "block" }}>
+              {source.language} · {source.source_type} · {source.jurisdiction}
+            </Typography>
+            <Typography variant="body1" sx={{ mb: 2, lineHeight: 1.6 }}>
+              {source.excerpt}
+            </Typography>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 2 }}>
+              {source.topics.map((topic) => (
+                <Chip key={topic} label={topic} size="small" sx={{ borderRadius: 0 }} />
+              ))}
+            </Box>
+            <Link href={source.url} target="_blank" rel="noopener noreferrer">
+              {source.url}
+            </Link>
+            {source.status === "pending" && (
+              <Box sx={{ mt: 2 }}>
+                <Button
+                  variant="contained"
+                  onClick={() => approveSource(source.id)}
+                  sx={{ borderRadius: 0, backgroundColor: bauhausColors.blue }}
+                >
+                  Approve
+                </Button>
+              </Box>
+            )}
+          </Paper>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default Literature;

--- a/frontend/src/pages/Literature.tsx
+++ b/frontend/src/pages/Literature.tsx
@@ -41,7 +41,8 @@ const Literature: React.FC = () => {
     try {
       const response = await fetch(apiUrl(`/api/v1/literature/sources?status=${status}`));
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        setSources([]);
+        return;
       }
       const data = await response.json();
       setSources(data.sources || []);

--- a/frontend/src/pages/Settings/GeneralSettings.tsx
+++ b/frontend/src/pages/Settings/GeneralSettings.tsx
@@ -32,6 +32,9 @@ const GeneralSettings: React.FC = () => {
 
   const handleSelectChange = (name: string) => (event: SelectChangeEvent) => {
     handleSettingChange(name, event.target.value);
+    if (name === "language") {
+      i18n.changeLanguage(event.target.value);
+    }
   };
 
   return (
@@ -49,10 +52,8 @@ const GeneralSettings: React.FC = () => {
               onChange={handleSelectChange("language")}
               label={t("settings.language")}
             >
-              <MenuItem value="en">English</MenuItem>
-              <MenuItem value="es">Español</MenuItem>
-              <MenuItem value="fr">Français</MenuItem>
-              <MenuItem value="de">Deutsch</MenuItem>
+              <MenuItem value="en-US">English</MenuItem>
+              <MenuItem value="zh-CN">简体中文</MenuItem>
             </Select>
           </FormControl>
         </Grid>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -18,6 +18,7 @@ import SecuritySettings from "../pages/Profile/SecuritySettings";
 import GeneralSettings from "../pages/Settings/GeneralSettings";
 import AppearanceSettings from "../pages/Settings/AppearanceSettings";
 import NotificationSettings from "../pages/Settings/NotificationSettings";
+import Literature from "../pages/Literature";
 
 import AnimatedPage from "../components/AnimatedPage";
 import ProtectedRoute from "../components/ProtectedRoute";
@@ -53,6 +54,9 @@ const AppRoutes: React.FC = () => {
         <Route path="chat" element={<Chat />} />
         <Route path="chat/history" element={<ChatHistory />} />
         <Route path="chat/settings" element={<ChatSettings />} />
+
+        {/* Literature Routes */}
+        <Route path="literature" element={<Literature />} />
 
         {/* Profile Routes */}
         <Route path="profile" element={<Profile />} />

--- a/frontend/src/test/components/Chat.test.tsx
+++ b/frontend/src/test/components/Chat.test.tsx
@@ -9,6 +9,38 @@ import { configureStore } from '@reduxjs/toolkit'
 import Chat from '../../components/Chat/Chat'
 import chatSlice from '../../store/slices/chatSlice'
 
+const { i18nState } = vi.hoisted(() => ({
+  i18nState: {
+    language: 'en-US',
+    changeLanguage: vi.fn(),
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+    i18n: i18nState,
+  }),
+}))
+
+vi.mock('../../components/common/VoiceInput', () => ({
+  default: ({
+    onTranscriptionComplete,
+    disabled,
+  }: {
+    onTranscriptionComplete: (text: string) => void
+    disabled?: boolean
+  }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onTranscriptionComplete('Voice message about condoms')}
+    >
+      Use voice
+    </button>
+  ),
+}))
+
 const mockStore = configureStore({
   reducer: {
     chat: chatSlice
@@ -23,6 +55,9 @@ const ChatWithProvider = () => (
 
 describe('Chat Component', () => {
   beforeEach(() => {
+    i18nState.language = 'en-US'
+    i18nState.changeLanguage.mockClear()
+    vi.mocked(fetch).mockClear()
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       status: 200,
@@ -42,6 +77,8 @@ describe('Chat Component', () => {
             source_type: 'official',
             url: 'https://www.cdc.gov/condom-use/index.html',
             excerpt: 'Condoms reduce the risk of many sexually transmitted infections.',
+            doi: '10.1000/example',
+            pmid: '12345678',
           },
         ],
       }),
@@ -67,6 +104,53 @@ describe('Chat Component', () => {
     })
   })
 
+  it('sends Simplified Chinese when the active UI locale is Chinese', async () => {
+    i18nState.language = 'zh-CN'
+    render(<ChatWithProvider />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '安全套如何帮助预防艾滋？' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: expect.stringContaining('"language":"zh-CN"'),
+        }),
+      )
+    })
+  })
+
+  it('sends message when Enter is pressed without Shift', async () => {
+    render(<ChatWithProvider />)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Enter key message' } })
+    fireEvent.keyPress(input, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: expect.stringContaining('Enter key message'),
+        }),
+      )
+    })
+  })
+
+  it('keeps multiline input when Shift Enter is pressed', () => {
+    render(<ChatWithProvider />)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Draft message' } })
+    fireEvent.keyPress(input, { key: 'Enter', code: 'Enter', shiftKey: true })
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(input).toHaveValue('Draft message')
+  })
+
   it('displays chat messages', () => {
     render(<ChatWithProvider />)
     expect(screen.getByTestId('chat-messages')).toBeInTheDocument()
@@ -79,6 +163,107 @@ describe('Chat Component', () => {
     fireEvent.click(submitButton)
     
     expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('sends voice transcription text through chat', async () => {
+    render(<ChatWithProvider />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use voice' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: expect.stringContaining('Voice message about condoms'),
+        }),
+      )
+    })
+  })
+
+  it('shows an assistant error message when the request fails', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('network unavailable'))
+    render(<ChatWithProvider />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'How do condoms help prevent STIs?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(
+      await screen.findByText('Sorry, I encountered an error. Please try again.', {}, { timeout: 2500 }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows an assistant error message when the response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    } as Response)
+    render(<ChatWithProvider />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'How do condoms help prevent STIs?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(
+      await screen.findByText('Sorry, I encountered an error. Please try again.', {}, { timeout: 2500 }),
+    ).toBeInTheDocument()
+  })
+
+  it('uses publisher name when no compact citation label exists', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        response: 'Searchable biomedical literature can support reviewable answers.',
+        language: 'en',
+        language_detected: 'en',
+        confidence: 0.95,
+        safety_score: 0.98,
+        status: 'answered',
+        citations: [
+          {
+            id: 'ncbi-sexual-health-literature',
+            title: 'NCBI Literature Resources',
+            publisher: 'National Center for Biotechnology Information',
+            language: 'en',
+            source_type: 'peer_reviewed',
+            url: 'https://www.ncbi.nlm.nih.gov/home/literature/',
+            excerpt: 'NCBI literature resources provide searchable biomedical literature records.',
+          },
+        ],
+      }),
+    } as Response)
+
+    render(<ChatWithProvider />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'What literature supports sexual health answers?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(
+      await screen.findByText('National Center for Biotechnology Information', {}, { timeout: 2500 }),
+    ).toBeInTheDocument()
+  })
+
+  it('clears rendered messages from the conversation', async () => {
+    render(<ChatWithProvider />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'How do condoms help prevent STIs?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(
+      await screen.findByText('Condoms can reduce STI risk when used correctly.', {}, { timeout: 2500 }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Clear Chat'))
+
+    expect(screen.queryByText('Condoms can reduce STI risk when used correctly.')).not.toBeInTheDocument()
   })
 
   it('shows citations returned with an assistant answer', async () => {
@@ -98,5 +283,52 @@ describe('Chat Component', () => {
 
     expect(screen.getByText('Condom Use and STI Prevention')).toBeInTheDocument()
     expect(screen.getByText('Centers for Disease Control and Prevention')).toBeInTheDocument()
+    expect(screen.getByText('PMID: 12345678')).toBeInTheDocument()
+    expect(screen.getByText('DOI: 10.1000/example')).toBeInTheDocument()
+  })
+
+  it('uses compact labels for Chinese official sources', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        response: '正确使用安全套有助于降低相关健康风险。',
+        language: 'zh-CN',
+        language_detected: 'zh-CN',
+        confidence: 0.95,
+        safety_score: 0.98,
+        status: 'answered',
+        citations: [
+          {
+            id: 'nhc-reproductive-health',
+            title: '生殖健康相关信息',
+            publisher: '国家卫生健康委员会',
+            language: 'zh-CN',
+            source_type: 'official',
+            url: 'https://www.nhc.gov.cn/',
+            excerpt: '生殖健康信息应以官方卫生健康资料为依据。',
+          },
+          {
+            id: 'china-cdc-hiv-prevention',
+            title: '艾滋病防治知识要点',
+            publisher: '中国疾病预防控制中心',
+            language: 'zh-CN',
+            source_type: 'official',
+            url: 'https://ncaids.chinacdc.cn/fazl/zsyd/index_4.htm',
+            excerpt: '正确了解艾滋病和性传播疾病预防知识。',
+          },
+        ],
+      }),
+    } as Response)
+
+    render(<ChatWithProvider />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '安全套如何帮助预防艾滋？' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(await screen.findByText('国家卫健委', {}, { timeout: 2500 })).toBeInTheDocument()
+    expect(screen.getByText('中国疾控')).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/components/Chat.test.tsx
+++ b/frontend/src/test/components/Chat.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import Chat from '../../components/Chat/Chat'
@@ -22,6 +22,32 @@ const ChatWithProvider = () => (
 )
 
 describe('Chat Component', () => {
+  beforeEach(() => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        response: 'Condoms can reduce STI risk when used correctly.',
+        language: 'en',
+        language_detected: 'en',
+        confidence: 0.95,
+        safety_score: 0.98,
+        status: 'answered',
+        citations: [
+          {
+            id: 'cdc-condoms-sti',
+            title: 'Condom Use and STI Prevention',
+            publisher: 'Centers for Disease Control and Prevention',
+            language: 'en',
+            source_type: 'official',
+            url: 'https://www.cdc.gov/condom-use/index.html',
+            excerpt: 'Condoms reduce the risk of many sexually transmitted infections.',
+          },
+        ],
+      }),
+    } as Response)
+  })
+
   it('renders chat interface', () => {
     render(<ChatWithProvider />)
     expect(screen.getByRole('textbox')).toBeInTheDocument()
@@ -53,5 +79,24 @@ describe('Chat Component', () => {
     fireEvent.click(submitButton)
     
     expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('shows citations returned with an assistant answer', async () => {
+    render(<ChatWithProvider />)
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'How do condoms help prevent STIs?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(
+      await screen.findByText('Condoms can reduce STI risk when used correctly.', {}, { timeout: 2500 }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('CDC')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('CDC'))
+
+    expect(screen.getByText('Condom Use and STI Prevention')).toBeInTheDocument()
+    expect(screen.getByText('Centers for Disease Control and Prevention')).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/components/GeneralSettings.test.tsx
+++ b/frontend/src/test/components/GeneralSettings.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for general settings.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import GeneralSettings from '../../pages/Settings/GeneralSettings'
+
+const { i18nState } = vi.hoisted(() => ({
+  i18nState: {
+    language: 'en-US',
+    changeLanguage: vi.fn(),
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: i18nState,
+  }),
+}))
+
+describe('GeneralSettings', () => {
+  beforeEach(() => {
+    i18nState.language = 'en-US'
+    i18nState.changeLanguage.mockClear()
+  })
+
+  it('renders the supported language choices and toggles', () => {
+    render(<GeneralSettings />)
+
+    expect(screen.getByText('settings.general')).toBeInTheDocument()
+    expect(screen.getByText('English')).toBeInTheDocument()
+    expect(screen.getByText('settings.darkMode')).toBeInTheDocument()
+    expect(screen.getByText('settings.notifications')).toBeInTheDocument()
+    expect(screen.getByText('settings.autoUpdate')).toBeInTheDocument()
+  })
+
+  it('changes the active i18n language from the selector', () => {
+    render(<GeneralSettings />)
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    fireEvent.click(screen.getByRole('option', { name: '简体中文' }))
+
+    expect(i18nState.changeLanguage).toHaveBeenCalledWith('zh-CN')
+  })
+
+  it('updates boolean settings when switches are toggled', () => {
+    render(<GeneralSettings />)
+
+    const darkModeSwitch = screen.getByLabelText('settings.darkMode')
+    expect(darkModeSwitch).not.toBeChecked()
+
+    fireEvent.click(darkModeSwitch)
+
+    expect(darkModeSwitch).toBeChecked()
+  })
+})

--- a/frontend/src/test/components/Literature.test.tsx
+++ b/frontend/src/test/components/Literature.test.tsx
@@ -41,6 +41,21 @@ describe('Literature page', () => {
     expect(screen.getByText('approved')).toBeInTheDocument()
   })
 
+  it('clears loading state when source loading fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response)
+
+    render(<Literature />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Literature')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Condom Use and STI Prevention')).not.toBeInTheDocument()
+  })
+
   it('submits a source for admin review', async () => {
     render(<Literature />)
 

--- a/frontend/src/test/components/Literature.test.tsx
+++ b/frontend/src/test/components/Literature.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for literature management UI.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Literature from '../../pages/Literature'
+
+describe('Literature page', () => {
+  beforeEach(() => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        sources: [
+          {
+            id: 'cdc-condoms-sti',
+            title: 'Condom Use and STI Prevention',
+            publisher: 'Centers for Disease Control and Prevention',
+            language: 'en',
+            source_type: 'official',
+            url: 'https://www.cdc.gov/condom-use/index.html',
+            topics: ['sti', 'condom'],
+            excerpt: 'Condoms reduce the risk of many sexually transmitted infections.',
+            status: 'approved',
+            jurisdiction: 'US',
+          },
+        ],
+      }),
+    } as Response)
+  })
+
+  it('renders approved sources for review', async () => {
+    render(<Literature />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Condom Use and STI Prevention')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Centers for Disease Control and Prevention')).toBeInTheDocument()
+    expect(screen.getByText('approved')).toBeInTheDocument()
+  })
+
+  it('submits a source for admin review', async () => {
+    render(<Literature />)
+
+    await screen.findByText('Condom Use and STI Prevention')
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'New Official Source' },
+    })
+    fireEvent.change(screen.getByLabelText('Publisher'), {
+      target: { value: 'Public Health Agency' },
+    })
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://example.org/source' },
+    })
+    fireEvent.change(screen.getByLabelText('Topics'), {
+      target: { value: 'sti, prevention' },
+    })
+    fireEvent.change(screen.getByLabelText('Excerpt'), {
+      target: { value: 'This reviewed public health source supports STI prevention education.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Submit source' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/literature/sources'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('approves pending sources from the review list', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ sources: [] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          sources: [
+            {
+              id: 'pending-source',
+              title: 'Pending STI Source',
+              publisher: 'Review Publisher',
+              language: 'en',
+              source_type: 'official',
+              url: 'https://example.org/pending',
+              topics: ['sti'],
+              excerpt: 'This pending source needs approval before use.',
+              status: 'pending',
+              jurisdiction: 'US',
+            },
+          ],
+        }),
+      } as Response)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ sources: [] }),
+      } as Response)
+
+    render(<Literature />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Pending' }))
+    await screen.findByText('Pending STI Source')
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/literature/sources/pending-source/approve'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -8,7 +8,7 @@ vi.stubGlobal('fetch', vi.fn(async () => ({
   json: async () => ({
     response: 'Test response',
     status: 'ready',
-    modelName: 'Gemma 3 1B',
+    modelName: 'Gemma 4 Health Tuned',
     memoryUsage: 0,
     responseTime: 0,
     version: 'test',


### PR DESCRIPTION
## Summary
- add source-backed chat responses with language gating, no-source refusal, and reviewable citations
- add approved literature registry APIs plus admin source submission/approval UI
- align app copy, config, and docs with a Gemma 4-derived local model and English/Simplified Chinese support

## Verification
- `git diff --check`
- `make test-backend` (57 passed)
- `make test-frontend` (37 passed)
- `cd frontend && npm run build`